### PR TITLE
Changed debug symbols type to full

### DIFF
--- a/craftersmine.SteamGridDB.Net/craftersmine.SteamGridDB.Net.csproj
+++ b/craftersmine.SteamGridDB.Net/craftersmine.SteamGridDB.Net.csproj
@@ -19,7 +19,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	  <DebugSymbols>True</DebugSymbols>
-	  <DebugType>pdbonly</DebugType>
+	  <DebugType>full</DebugType>
   </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Changed debug symbols type to full in order to snupkg package being appoved as portable symbols