### PR TITLE
Added URI double-escape to fix issue with search

### DIFF
--- a/craftersmine.SteamGridDB.Net/SteamGridDb.cs
+++ b/craftersmine.SteamGridDB.Net/SteamGridDb.cs
@@ -1342,6 +1342,7 @@ namespace craftersmine.SteamGridDBNet
         /// <exception cref="SteamGridDbException">When unknown exception occurred in request</exception>
         public async Task<SteamGridDbGame[]> SearchForGamesAsync(string searchTerm)
         {
+            searchTerm = Uri.EscapeDataString(Uri.EscapeDataString(searchTerm));
             var response = await Get($"search/autocomplete/{searchTerm}");
             if (response.Data != null) return response.Data.ToObject<SteamGridDbGame[]>();
             return null;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Added URI double-escape to fix issue with search. Unescaped or single-escaped string results in incomplete search results

Does this close any currently open issues?
------------------------------------------
- #12 

Any other comments?
-------------------
Unfortunatelly, it should be done it that way because of API endpoint behaviour

Where has this been tested?
---------------------------
**Operating System:** Windows 11 22H2 x64 Release Channel

**Platform:** .NET 6.0.414 x64

**Library version:** 1.1.7
